### PR TITLE
Revert changes to FaultContractNamespace

### DIFF
--- a/source/Src/Validation.WCF/ValidationConstants.cs
+++ b/source/Src/Validation.WCF/ValidationConstants.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Practices.EnterpriseLibrary.Validation.Integration.WCF
         /// 
         /// </summary>
         public const string FaultContractNamespace =
-            "http://www.microsoft.com/practices/Microsoft.Practices.EnterpriseLibrary/2007/01/wcf/validation";
+            "http://www.microsoft.com/practices/EnterpriseLibrary/2007/01/wcf/validation";
     }
 }


### PR DESCRIPTION
The change to `FaultContractNamespace` is a breaking change when deserializing types.
I assume that was not intended and happened by coincidence.