### PR TITLE
Added net472, net6.0, net7.0 as build targets

### DIFF
--- a/source/Src/Validation.AspNet/Validation.Integration.AspNet.csproj
+++ b/source/Src/Validation.AspNet/Validation.Integration.AspNet.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>

--- a/source/Src/Validation.Integration.WPF/Validation.Integration.WPF.csproj
+++ b/source/Src/Validation.Integration.WPF/Validation.Integration.WPF.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472;netcoreapp3.0</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>

--- a/source/Src/Validation.Integration.WPF/Validation.Integration.WPF.csproj
+++ b/source/Src/Validation.Integration.WPF/Validation.Integration.WPF.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472;netcoreapp3.0;net6.0-windows;net7.0-windows</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>
@@ -39,11 +39,7 @@
     <ProjectReference Include="..\Validation\Validation.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">
-
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) AND !$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />
@@ -91,14 +87,6 @@
       <Visible>False</Visible>
       <PackagePath>tools</PackagePath>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">
-
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) AND !$(TargetFramework.StartsWith('netcoreapp'))">
-
   </ItemGroup>
 
   <PropertyGroup>

--- a/source/Src/Validation.WCF/Validation.Integration.WCF.csproj
+++ b/source/Src/Validation.WCF/Validation.Integration.WCF.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472;</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>

--- a/source/Src/Validation.WinForms/Validation.Integration.WinForms.csproj
+++ b/source/Src/Validation.WinForms/Validation.Integration.WinForms.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472;netcoreapp3.0;net6.0-windows;net7.0-windows</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>
@@ -41,7 +41,7 @@
 
   </ItemGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) AND !$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Configuration" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Design" />
@@ -95,14 +95,6 @@
       <Visible>False</Visible>
       <PackagePath>tools</PackagePath>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">
-
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) AND !$(TargetFramework.StartsWith('netcoreapp'))">
-
   </ItemGroup>
 
   <PropertyGroup>

--- a/source/Src/Validation.WinForms/Validation.Integration.WinForms.csproj
+++ b/source/Src/Validation.WinForms/Validation.Integration.WinForms.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472;netcoreapp3.0</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>

--- a/source/Src/Validation/Validation.csproj
+++ b/source/Src/Validation/Validation.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;netstandard2.0;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472;netstandard2.0;netcoreapp2.0;netcoreapp3.0;net6.0;net7.0</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>
@@ -33,7 +33,7 @@
     <PackageReference Include="$(PrePackageName).Common$(PostPackageName)" Version="$(EntLibCommonVersion)" Condition="!Exists('$(EntLibCommon)') OR '$(EntLibDependencyType)' == 'Package'" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotationsVersion)" />
   </ItemGroup>
@@ -44,7 +44,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) AND !$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Configuration.Install" />
@@ -108,7 +108,7 @@
     <Compile Remove="**\*.Desktop.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) AND !$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Compile Remove="**\*.Core.cs" />
   </ItemGroup>
 

--- a/source/Tests/Integration.WCF.Tests/Validation.Integration.WCF.Tests.VSTS.csproj
+++ b/source/Tests/Integration.WCF.Tests/Validation.Integration.WCF.Tests.VSTS.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net47</TargetFrameworks>
+    <TargetFrameworks>net47;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/source/Tests/Integration.WPF.Tests/Validation.Integration.WPF.Tests.VSTS.csproj
+++ b/source/Tests/Integration.WPF.Tests/Validation.Integration.WPF.Tests.VSTS.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net47</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net47;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/source/Tests/Integration.WinForms.Tests/Validation.Integration.WinForms.Tests.VSTS.csproj
+++ b/source/Tests/Integration.WinForms.Tests/Validation.Integration.WinForms.Tests.VSTS.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net47;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net47;net472;netcoreapp3.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/source/Tests/Validation.TestSupport/Validation.TestSupport.csproj
+++ b/source/Tests/Validation.TestSupport/Validation.TestSupport.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472;netcoreapp3.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/source/Tests/Validation.Tests/Validation.Tests.VSTS.csproj
+++ b/source/Tests/Validation.Tests/Validation.Tests.VSTS.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net47</TargetFrameworks>
+    <TargetFrameworks>net47;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>


### PR DESCRIPTION
Added net472, net6.0, net7.0 as build targets to Common, Validation and Logging blocks. Unlike net standard builds it allows to include some windows functionality like event log code.